### PR TITLE
Add featured size variant for donor photos

### DIFF
--- a/src/components/shared/DonorPhoto.jsx
+++ b/src/components/shared/DonorPhoto.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 const sizeClasses = {
   small: 'w-20 h-20 rounded',
+  featured: 'w-28 h-28 rounded-md shadow-sm',
   large: 'w-48 h-48 rounded-lg shadow-md border border-slate-200',
 };
 
@@ -44,7 +45,7 @@ const DonorPhoto = ({ donorId, donorName, size = 'small', className = '' }) => {
 DonorPhoto.propTypes = {
   donorId: PropTypes.string.isRequired,
   donorName: PropTypes.string.isRequired,
-  size: PropTypes.oneOf(['small', 'large']),
+  size: PropTypes.oneOf(['small', 'featured', 'large']),
   className: PropTypes.string,
 };
 

--- a/src/pages/DonorList.jsx
+++ b/src/pages/DonorList.jsx
@@ -82,7 +82,7 @@ const DonorList = () => {
       label: '',
       render: (donor) => (
         <div className="flex justify-center">
-          <DonorPhoto donorId={donor.id} donorName={donor.name} size="small" />
+          <DonorPhoto donorId={donor.id} donorName={donor.name} size={donor.rank === 1 ? 'featured' : 'small'} />
         </div>
       ),
     },


### PR DESCRIPTION
## Summary
Added a new "featured" size variant for the DonorPhoto component to highlight top-ranked donors in the donor list with a medium-sized photo display.

## Key Changes
- Added `featured` size class to DonorPhoto component with dimensions `w-28 h-28` and subtle shadow styling
- Updated DonorPhoto propTypes to include the new `featured` size option
- Modified DonorList to conditionally render featured-sized photos for rank 1 donors, while keeping other donors at small size

## Implementation Details
- The featured size uses `rounded-md` for slightly more rounded corners than small but less than large
- Applied `shadow-sm` for a subtle depth effect that distinguishes featured donors without being as prominent as the large variant
- The conditional rendering in DonorList uses a ternary operator to check `donor.rank === 1` to determine which size to display

https://claude.ai/code/session_01NSu9xPJrT753WmU9MRqvKN